### PR TITLE
Allow compilation on Adafruit Trinket

### DIFF
--- a/Adafruit_Si4713.cpp
+++ b/Adafruit_Si4713.cpp
@@ -304,7 +304,9 @@ uint8_t Adafruit_Si4713::getStatus(void) {
    Wire.endTransmission();
    Wire.requestFrom((uint8_t)_i2caddr, (uint8_t)1);  
    while (Wire.available() < 1) {
-     Serial.print('.');
+#ifdef SI4713_CMD_DEBUG
+    Serial.print('.');
+#endif 
      delay(1);
    }
    return  Wire.read();


### PR DESCRIPTION
This change enables compilation in ArduinoIDE with Adafruit Trinket as a target board. Trinket does not have Serial port so it is not possible to run adaradio example.