### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_Si4713.h
+++ b/Adafruit_Si4713.h
@@ -20,12 +20,8 @@
  *  BSD license, all text above must be included in any redistribution
  */
 
-#if (ARDUINO >= 100)
 #include "Arduino.h"
-#else
-#include "WProgram.h"
-#endif
-#include <Wire.h>
+#include <Adafruit_I2CDevice.h>
 
 //#define SI471X_CMD_DEBUG
 #define SI4710_ADDR0 0x11      ///< if SEN is low
@@ -190,6 +186,5 @@ private:
 
   int8_t _rst;
   uint8_t _i2ccommand[10]; // holds the command buffer
-  uint8_t _i2caddr;
-  TwoWire *_wire;
+  Adafruit_I2CDevice *i2c_dev = NULL;
 };

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit Si4713 Library
-version=1.1.3
+version=1.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for the Si4714 FM+RDS Transmitter in the Adafruit shop
@@ -7,3 +7,4 @@ paragraph=Arduino library for the Si4714 FM+RDS Transmitter in the Adafruit shop
 category=Communication
 url=https://github.com/adafruit/Adafruit-Si4713-Library
 architectures=*
+depends=Adafruit BusIO


### PR DESCRIPTION
For #8. Converts to BusIO usage.

Tested using `adaradio.ino` example sketch on Itsy M0.