### PR TITLE
Add delay() in adaradio example, to fix power-up timing isssue

### DIFF
--- a/examples/adaradio/adaradio.ino
+++ b/examples/adaradio/adaradio.ino
@@ -37,6 +37,8 @@ void setup() {
     while (1);
   }
 
+  delay(1000);  // may be needed for initial power timing; increase to 2000 if radio does not consistently start up
+  
   // Uncomment to scan power of entire range from 87.5 to 108.0 MHz
   /*
   for (uint16_t f  = 8750; f<10800; f+=10) {

--- a/examples/adaradio/adaradio.ino
+++ b/examples/adaradio/adaradio.ino
@@ -37,7 +37,7 @@ void setup() {
     while (1);
   }
 
-  delay(1000);  // may be needed for initial power timing; increase to 2000 if radio does not consistently start up
+  delay(1000);  // may be needed for initial power-up timing; increase to 2000 if radio does not consistently start up
   
   // Uncomment to scan power of entire range from 87.5 to 108.0 MHz
   /*


### PR DESCRIPTION
In the "adaradio.ino" example, this change adds delay(1000); after the radio.begin() while loop to fix a power-up timing issue described in posts 8, 9, and 10 in this topic of the Adafruit forum:  https://forums.adafruit.com/viewtopic.php?t=199697
